### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Depends:
     methods,
     Rcpp (>= 0.12.0)
 Imports:
-    rstan (>= 2.18),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     reshape2,
     mvtnorm,
@@ -45,9 +45,9 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.2),
-    StanHeaders (>= 2.18.0),
+    StanHeaders (>= 2.26.0),
     BH (>= 1.66.0),
-    rstan (>= 2.18.1)
+    rstan (>= 2.26.0)
 VignetteBuilder:
     knitr
 RdMacros:

--- a/inst/stan/correlation.stan
+++ b/inst/stan/correlation.stan
@@ -10,22 +10,22 @@ data {
   int<lower=1> N;               // observations
   int<lower=1> numRefresh;      // when change in item/pa1/pa2
   int<lower=1> NITEMS;
-  int<lower=1> NTHRESH[NITEMS];         // number of thresholds
-  int<lower=1> TOFFSET[NITEMS];
+  array[NITEMS] int<lower=1> NTHRESH;         // number of thresholds
+  array[NITEMS] int<lower=1> TOFFSET;
   vector[NITEMS] scale;
   real corLKJPrior;
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
-  int item[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
+  array[numRefresh] int item;
 }
 transformed data {
   int totalThresholds = sum(NTHRESH);
-  int rcat[NCMP];
+  array[NCMP] int rcat;
   {
     int cmpStart = 0;
     for (rx in 1:numRefresh) {

--- a/inst/stan/correlation_ll.stan
+++ b/inst/stan/correlation_ll.stan
@@ -10,22 +10,22 @@ data {
   int<lower=1> N;               // observations
   int<lower=1> numRefresh;      // when change in item/pa1/pa2
   int<lower=1> NITEMS;
-  int<lower=1> NTHRESH[NITEMS];         // number of thresholds
-  int<lower=1> TOFFSET[NITEMS];
+  array[NITEMS] int<lower=1> NTHRESH;         // number of thresholds
+  array[NITEMS] int<lower=1> TOFFSET;
   vector[NITEMS] scale;
   real corLKJPrior;
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
-  int item[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
+  array[numRefresh] int item;
 }
 transformed data {
   int totalThresholds = sum(NTHRESH);
-  int rcat[NCMP];
+  array[NCMP] int rcat;
   {
     int cmpStart = 0;
     for (rx in 1:numRefresh) {
@@ -81,7 +81,7 @@ model {
   }
 }
 generated quantities {
-  real log_lik[N];
+  array[N] real log_lik;
 
   corr_matrix[NITEMS] thetaCor;
   thetaCor = multiply_lower_tri_self_transpose(rawThetaCorChol);

--- a/inst/stan/factor.stan
+++ b/inst/stan/factor.stan
@@ -10,26 +10,26 @@ data {
   int<lower=1> N;               // observations
   int<lower=1> numRefresh;      // when change in item/pa1/pa2
   int<lower=1> NITEMS;
-  int<lower=1> NTHRESH[NITEMS];         // number of thresholds
-  int<lower=1> TOFFSET[NITEMS];
+  array[NITEMS] int<lower=1> NTHRESH;         // number of thresholds
+  array[NITEMS] int<lower=1> TOFFSET;
   vector[NITEMS] scale;
   real propShape;
   int<lower=1> NFACTORS;
-  real factorScalePrior[NFACTORS];
+  array[NFACTORS] real factorScalePrior;
   int<lower=1> NPATHS;
-  int factorItemPath[2,NPATHS];  // 1 is factor index, 2 is item index
+  array[2,NPATHS] int factorItemPath;  // 1 is factor index, 2 is item index
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
-  int item[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
+  array[numRefresh] int item;
 }
 transformed data {
   int totalThresholds = sum(NTHRESH);
-  int rcat[NCMP];
+  array[NCMP] int rcat;
   vector[NPATHS] pathScalePrior;
   {
     int cmpStart = 0;
@@ -54,7 +54,7 @@ transformed data {
   }
 }
 parameters {
-  real<lower=0> alpha[NITEMS];
+  array[NITEMS] real<lower=0> alpha;
   vector<lower=0,upper=1>[totalThresholds] rawThreshold;
   cholesky_factor_corr[NFACTORS] CholPsi;
   matrix[NPA,NFACTORS] rawFactor;      // do not interpret, see factor
@@ -68,7 +68,7 @@ transformed parameters {
   matrix[NPA,NFACTORS] rawFactorPsi;
   matrix[NPA,NITEMS] theta;
   vector[NPATHS] rawPathProp;  // always positive
-  real rawPerComponentVar[NITEMS,1+NFACTORS];
+  array[NITEMS,1+NFACTORS] real rawPerComponentVar;
   for (ix in 1:NITEMS) {
     theta[,ix] = rawUniqueTheta[,ix] * (2*rawUnique[ix]-1);
     rawPerComponentVar[ix, 1] = variance(theta[,ix]);
@@ -152,8 +152,8 @@ generated quantities {
 
   {
     vector[NPATHS] pathLoadings = (2*rawLoadings-1);
-    int rawSeenFactor[NFACTORS];
-    int rawNegateFactor[NFACTORS];
+    array[NFACTORS] int rawSeenFactor;
+    array[NFACTORS] int rawNegateFactor;
     for (fx in 1:NFACTORS) rawSeenFactor[fx] = 0;
     for (px in 1:NPATHS) {
       int fx = factorItemPath[1,px];

--- a/inst/stan/factor1.stan
+++ b/inst/stan/factor1.stan
@@ -10,26 +10,26 @@ data {
   int<lower=1> N;               // observations
   int<lower=1> numRefresh;      // when change in item/pa1/pa2
   int<lower=1> NITEMS;
-  int<lower=1> NTHRESH[NITEMS];         // number of thresholds
-  int<lower=1> TOFFSET[NITEMS];
+  array[NITEMS] int<lower=1> NTHRESH;         // number of thresholds
+  array[NITEMS] int<lower=1> TOFFSET;
   vector[NITEMS] scale;
   real propShape;
   int<lower=1> NFACTORS;
-  real factorScalePrior[NFACTORS];
+  array[NFACTORS] real factorScalePrior;
   int<lower=1> NPATHS;
-  int factorItemPath[2,NPATHS];  // 1 is factor index, 2 is item index
+  array[2,NPATHS] int factorItemPath;  // 1 is factor index, 2 is item index
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
-  int item[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
+  array[numRefresh] int item;
 }
 transformed data {
   int totalThresholds = sum(NTHRESH);
-  int rcat[NCMP];
+  array[NCMP] int rcat;
   vector[NPATHS] pathScalePrior;
   {
     int cmpStart = 0;
@@ -54,7 +54,7 @@ transformed data {
   }
 }
 parameters {
-  real<lower=0> alpha[NITEMS];
+  array[NITEMS] real<lower=0> alpha;
   vector<lower=0,upper=1>[totalThresholds] rawThreshold;
   matrix[NPA,NFACTORS] rawFactor;      // do not interpret, see factor
   vector<lower=0,upper=1>[NPATHS] rawLoadings; // do not interpret, see factorLoadings
@@ -66,7 +66,7 @@ transformed parameters {
   vector[totalThresholds] rawCumTh;
   matrix[NPA,NITEMS] theta;
   vector[NPATHS] rawPathProp;  // always positive
-  real rawPerComponentVar[NITEMS,1+NFACTORS];
+  array[NITEMS,1+NFACTORS] real rawPerComponentVar;
   for (ix in 1:NITEMS) {
     theta[,ix] = rawUniqueTheta[,ix] * (2*rawUnique[ix]-1);
     rawPerComponentVar[ix, 1] = variance(theta[,ix]);
@@ -145,8 +145,8 @@ generated quantities {
 
   {
     vector[NPATHS] pathLoadings = (2*rawLoadings-1);
-    int rawSeenFactor[NFACTORS];
-    int rawNegateFactor[NFACTORS];
+    array[NFACTORS] int rawSeenFactor;
+    array[NFACTORS] int rawNegateFactor;
     for (fx in 1:NFACTORS) rawSeenFactor[fx] = 0;
     for (px in 1:NPATHS) {
       int fx = factorItemPath[1,px];

--- a/inst/stan/factor1_ll.stan
+++ b/inst/stan/factor1_ll.stan
@@ -10,26 +10,26 @@ data {
   int<lower=1> N;               // observations
   int<lower=1> numRefresh;      // when change in item/pa1/pa2
   int<lower=1> NITEMS;
-  int<lower=1> NTHRESH[NITEMS];         // number of thresholds
-  int<lower=1> TOFFSET[NITEMS];
+  array[NITEMS] int<lower=1> NTHRESH;         // number of thresholds
+  array[NITEMS] int<lower=1> TOFFSET;
   vector[NITEMS] scale;
   real propShape;
   int<lower=1> NFACTORS;
-  real factorScalePrior[NFACTORS];
+  array[NFACTORS] real factorScalePrior;
   int<lower=1> NPATHS;
-  int factorItemPath[2,NPATHS];  // 1 is factor index, 2 is item index
+  array[2,NPATHS] int factorItemPath;  // 1 is factor index, 2 is item index
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
-  int item[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
+  array[numRefresh] int item;
 }
 transformed data {
   int totalThresholds = sum(NTHRESH);
-  int rcat[NCMP];
+  array[NCMP] int rcat;
   vector[NPATHS] pathScalePrior;
   {
     int cmpStart = 0;
@@ -54,7 +54,7 @@ transformed data {
   }
 }
 parameters {
-  real<lower=0> alpha[NITEMS];
+  array[NITEMS] real<lower=0> alpha;
   vector<lower=0,upper=1>[totalThresholds] rawThreshold;
   matrix[NPA,NFACTORS] rawFactor;      // do not interpret, see factor
   vector<lower=0,upper=1>[NPATHS] rawLoadings; // do not interpret, see factorLoadings
@@ -66,7 +66,7 @@ transformed parameters {
   vector[totalThresholds] rawCumTh;
   matrix[NPA,NITEMS] theta;
   vector[NPATHS] rawPathProp;  // always positive
-  real rawPerComponentVar[NITEMS,1+NFACTORS];
+  array[NITEMS,1+NFACTORS] real rawPerComponentVar;
   for (ix in 1:NITEMS) {
     theta[,ix] = rawUniqueTheta[,ix] * (2*rawUnique[ix]-1);
     rawPerComponentVar[ix, 1] = variance(theta[,ix]);
@@ -128,7 +128,7 @@ model {
   target += normal_lpdf(logit(0.5 + rawPathProp/2.0) | 0, pathScalePrior);
 }
 generated quantities {
-  real log_lik[N];
+  array[N] real log_lik;
 
   vector[NPATHS] pathProp = rawPathProp;
   matrix[NPA,NFACTORS] factor = rawFactor;
@@ -147,8 +147,8 @@ generated quantities {
 
   {
     vector[NPATHS] pathLoadings = (2*rawLoadings-1);
-    int rawSeenFactor[NFACTORS];
-    int rawNegateFactor[NFACTORS];
+    array[NFACTORS] int rawSeenFactor;
+    array[NFACTORS] int rawNegateFactor;
     for (fx in 1:NFACTORS) rawSeenFactor[fx] = 0;
     for (px in 1:NPATHS) {
       int fx = factorItemPath[1,px];

--- a/inst/stan/factor_ll.stan
+++ b/inst/stan/factor_ll.stan
@@ -10,26 +10,26 @@ data {
   int<lower=1> N;               // observations
   int<lower=1> numRefresh;      // when change in item/pa1/pa2
   int<lower=1> NITEMS;
-  int<lower=1> NTHRESH[NITEMS];         // number of thresholds
-  int<lower=1> TOFFSET[NITEMS];
+  array[NITEMS] int<lower=1> NTHRESH;         // number of thresholds
+  array[NITEMS] int<lower=1> TOFFSET;
   vector[NITEMS] scale;
   real propShape;
   int<lower=1> NFACTORS;
-  real factorScalePrior[NFACTORS];
+  array[NFACTORS] real factorScalePrior;
   int<lower=1> NPATHS;
-  int factorItemPath[2,NPATHS];  // 1 is factor index, 2 is item index
+  array[2,NPATHS] int factorItemPath;  // 1 is factor index, 2 is item index
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
-  int item[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
+  array[numRefresh] int item;
 }
 transformed data {
   int totalThresholds = sum(NTHRESH);
-  int rcat[NCMP];
+  array[NCMP] int rcat;
   vector[NPATHS] pathScalePrior;
   {
     int cmpStart = 0;
@@ -54,7 +54,7 @@ transformed data {
   }
 }
 parameters {
-  real<lower=0> alpha[NITEMS];
+  array[NITEMS] real<lower=0> alpha;
   vector<lower=0,upper=1>[totalThresholds] rawThreshold;
   cholesky_factor_corr[NFACTORS] CholPsi;
   matrix[NPA,NFACTORS] rawFactor;      // do not interpret, see factor
@@ -68,7 +68,7 @@ transformed parameters {
   matrix[NPA,NFACTORS] rawFactorPsi;
   matrix[NPA,NITEMS] theta;
   vector[NPATHS] rawPathProp;  // always positive
-  real rawPerComponentVar[NITEMS,1+NFACTORS];
+  array[NITEMS,1+NFACTORS] real rawPerComponentVar;
   for (ix in 1:NITEMS) {
     theta[,ix] = rawUniqueTheta[,ix] * (2*rawUnique[ix]-1);
     rawPerComponentVar[ix, 1] = variance(theta[,ix]);
@@ -134,7 +134,7 @@ model {
   target += normal_lpdf(logit(0.5 + rawPathProp/2.0) | 0, pathScalePrior);
 }
 generated quantities {
-  real log_lik[N];
+  array[N] real log_lik;
 
   vector[NPATHS] pathProp = rawPathProp;
   matrix[NPA,NFACTORS] factor = rawFactorPsi;
@@ -154,8 +154,8 @@ generated quantities {
 
   {
     vector[NPATHS] pathLoadings = (2*rawLoadings-1);
-    int rawSeenFactor[NFACTORS];
-    int rawNegateFactor[NFACTORS];
+    array[NFACTORS] int rawSeenFactor;
+    array[NFACTORS] int rawNegateFactor;
     for (fx in 1:NFACTORS) rawSeenFactor[fx] = 0;
     for (px in 1:NPATHS) {
       int fx = factorItemPath[1,px];

--- a/inst/stan/functions/pairwise.stan
+++ b/inst/stan/functions/pairwise.stan
@@ -1,7 +1,7 @@
-vector cmp_probs(real scale, real alpha, real pa1, real pa2, vector thr, int[] want) {
+vector cmp_probs(real scale, real alpha, real pa1, real pa2, vector thr, array[] int want) {
   int nth = num_elements(thr);
   int nth2 = nth*2;
-  real pr[1+nth2];
+  array[1+nth2] real pr;
   vector[1 + nth2] out;
   real paDiff = alpha * scale * (pa1 - pa2);
   vector[nth] thrAlpha = thr * alpha;
@@ -32,13 +32,13 @@ vector cmp_probs(real scale, real alpha, real pa1, real pa2, vector thr, int[] w
   return out;
 }
 
-real pairwise_logprob(int[] rcat, int[] weight, int cmpStart, int len,
+real pairwise_logprob(array[] int rcat, array[] int weight, int cmpStart, int len,
                       real scale, real alpha, real pa1, real pa2, vector cumTh)
 {
   real lp = 0;
   int nth = num_elements(cumTh);
   vector[1+nth*2] prob;
-  int want[1+nth*2];
+  array[1+nth*2] int want;
   for (ox in 1:num_elements(want)) want[ox] = 0;
   for (ox in cmpStart:(cmpStart + len - 1)) {
     want[ rcat[ox] ] = 1;
@@ -55,14 +55,14 @@ real pairwise_logprob(int[] rcat, int[] weight, int cmpStart, int len,
   return lp;
 }
 
-real[] pairwise_loo(int[] rcat, int[] weight, int numOutcome, int cmpStart, int len,
+array[] real pairwise_loo(array[] int rcat, array[] int weight, int numOutcome, int cmpStart, int len,
                   real scale, real alpha, real pa1, real pa2, vector cumTh)
 {
-  real lp[numOutcome];
+  array[numOutcome] real lp;
   int cur = 1;
   int nth = num_elements(cumTh);
   vector[1+nth*2] prob;
-  int want[1+nth*2];
+  array[1+nth*2] int want;
   for (ox in 1:num_elements(want)) want[ox] = 0;
   for (ox in cmpStart:(cmpStart + len - 1)) {
     want[ rcat[ox] ] = 1;

--- a/inst/stan/unidim.stan
+++ b/inst/stan/unidim.stan
@@ -12,15 +12,15 @@ data {
   int<lower=1> NTHRESH;         // number of thresholds
   real scale;
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
 }
 transformed data {
-  int rcat[NCMP];
+  array[NCMP] int rcat;
 
   for (cmp in 1:NCMP) {
     rcat[cmp] = pick[cmp] + NTHRESH + 1;

--- a/inst/stan/unidim_adapt.stan
+++ b/inst/stan/unidim_adapt.stan
@@ -12,15 +12,15 @@ data {
   int<lower=1> NTHRESH;         // number of thresholds
   real varCorrection;
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
 }
 transformed data {
-  int rcat[NCMP];
+  array[NCMP] int rcat;
   real alpha = 1.749;
 
   for (cmp in 1:NCMP) {

--- a/inst/stan/unidim_ll.stan
+++ b/inst/stan/unidim_ll.stan
@@ -12,15 +12,15 @@ data {
   int<lower=1> NTHRESH;         // number of thresholds
   real scale;
   // response data
-  int<lower=1, upper=NPA> pa1[numRefresh];
-  int<lower=1, upper=NPA> pa2[numRefresh];
-  int weight[NCMP];
-  int pick[NCMP];
-  int refresh[numRefresh];
-  int numOutcome[numRefresh];
+  array[numRefresh] int<lower=1, upper=NPA> pa1;
+  array[numRefresh] int<lower=1, upper=NPA> pa2;
+  array[NCMP] int weight;
+  array[NCMP] int pick;
+  array[numRefresh] int refresh;
+  array[numRefresh] int numOutcome;
 }
 transformed data {
-  int rcat[NCMP];
+  array[NCMP] int rcat;
 
   for (cmp in 1:NCMP) {
     rcat[cmp] = pick[cmp] + NTHRESH + 1;
@@ -54,7 +54,7 @@ model {
   }
 }
 generated quantities {
-  real log_lik[N];
+  array[N] real log_lik;
 
   vector[NPA] theta = rawTheta;
   theta -= mean(theta);


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
